### PR TITLE
Update documentation for M1+M2 completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,27 +8,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+#### Milestone 2: Typed Tools
+- JSON Schema parser (`JsonSchemaParser`) for parsing MCP tool schemas
+- C# type mapper (`CSharpTypeMapper`) for JSON → C# type conversion
+- DTO code generator (`DtoGenerator`) for generating C# records from schemas
+- CLI `pull-tools` command for MCP tool discovery
+- CLI `gen` command for generating DTOs from tool manifests
+- Support for nested objects, arrays, format hints (date-time, uri, uuid)
+- netstandard2.0 compatibility with appropriate fallbacks
+
+#### Milestone 1: Hello MCP
+- MCP client (`McpClient`) with JSON-RPC 2.0 protocol
+- Stdio transport (`StdioMcpTransport`) for process-based communication
+- Tool discovery via `tools/list` RPC
+- Tool invocation via `tools/call` RPC
+- Async request/response correlation with thread-safe queueing
+
+#### Milestone 0: Build Foundation
 - Initial project structure
 - Core abstractions: `ToolContract`, `ToolCall`, `ToolResult`
 - Policy pipeline: `IPolicy`, `PolicyPipeline`
 - Tracing primitives: `TraceEvent`, `ITraceSink`
-- MCP client interfaces: `IMcpClient`, `McpClientAdapter` (placeholder)
-- Roslyn source generator skeleton: `ToolGenerator`
 - `[Tool]` attribute for marking tool methods
-- CLI skeleton with placeholder commands
 - Test projects for all libraries
 - GitHub Actions CI/CD workflows
 - .editorconfig for code style consistency
 - NuGet package metadata for all projects
 
 ### Infrastructure
-- Build succeeds on .NET 6.0
-- All tests passing
+- Multi-target builds: netstandard2.0, net6.0, net8.0
+- CodeQL security scanning
+- All tests passing (34 tests)
 - CI runs on every push/PR
-- Release workflow ready for NuGet publishing
 
 ## [0.1.0-alpha] - TBD
 
-First alpha release - coming soon!
+First alpha release targeting Milestone 3 completion.
 
 [Unreleased]: https://github.com/thiagocharao/aifirst-dotnet/compare/main...HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,13 @@
 # Contributing to AIFirst.DotNet
 
-Thank you for considering contributing to AIFirst.DotNet! This project is in early development.
+Thank you for considering contributing to AIFirst.DotNet!
 
 ## Development Status
 
-🚧 **MVP in Progress** — The project is currently building out core functionality through Milestone 4. Contributions are welcome once Milestone 3 is complete.
+Track development progress on the [Issues page](https://github.com/thiagocharao/aifirst-dotnet/issues).
+
+**Completed:** M0 (Foundation), M1 (MCP Client), M2 (Typed Tools)  
+**In Progress:** M3 (Source Generator)
 
 ## Getting Started
 
@@ -17,8 +20,8 @@ Thank you for considering contributing to AIFirst.DotNet! This project is in ear
 ### Setup
 
 ```bash
-git clone https://github.com/thiagocharao/ai-first.git
-cd ai-first
+git clone https://github.com/thiagocharao/aifirst-dotnet.git
+cd aifirst-dotnet
 dotnet restore
 dotnet build
 dotnet test

--- a/README.md
+++ b/README.md
@@ -4,28 +4,46 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-8.0-purple.svg)](https://dotnet.microsoft.com/)
 
-AIFirst.DotNet is an AI-first .NET SDK that makes MCP tool-calling feel like native C# with compile-time safety, policy enforcement, and observability. The MVP uses an attribute-based DSL so tool contracts become strongly-typed methods with analyzer support.
+AIFirst.DotNet is an AI-first .NET SDK that makes MCP tool-calling feel like native C# with compile-time safety, policy enforcement, and observability.
 
-## Why AIFirst.DotNet?
+## The Problem
 
-If you're building AI-powered applications in .NET, you've likely hit these problems:
+When building AI agents that call external tools, you face:
 
-- 🔴 **Runtime tool failures** — typos in tool names, schema mismatches
-- 🔴 **Security concerns** — PII leakage, prompt injection via tool outputs
-- 🔴 **Debugging nightmares** — "Why did the agent do that?"
-- 🔴 **Governance gaps** — no allowlists, no audit trails
+| Problem | Impact |
+|---------|--------|
+| Typo in tool name | Runtime crash in production |
+| Schema mismatch | Silent failures, weird behavior |
+| PII in logs | Compliance violations |
+| "Why did AI do that?" | Impossible to debug |
 
-AIFirst.DotNet solves these with:
+## The Solution
 
-✅ **Compile-time safety** — tool calls are strongly-typed, validated at build time  
-✅ **Policy enforcement** — allowlists, redaction, and output checks built-in  
-✅ **Observability** — trace every prompt and tool call for debugging and compliance  
-✅ **MCP-native** — leverage the emerging standard for tool interoperability
+AIFirst.DotNet gives you typed tool calls with build-time validation:
 
-## Features
+```csharp
+// ❌ Without AIFirst: Runtime errors, no safety
+var result = await llm.CallTool("send_emal", jsonArgs); // typo discovered in prod
 
-### MCP Client
-Connect to any MCP-compliant server and discover tools:
+// ✅ With AIFirst: Compile-time safety
+[Tool("email.send")]
+public partial Task<EmailResult> SendEmailAsync(SendEmailRequest request);
+// ^ Build fails if tool doesn't exist or schema is wrong
+```
+
+**See [Use Cases](docs/use-cases.md) for detailed scenarios and when to use AIFirst.DotNet.**
+
+## Quick Start
+
+```bash
+# 1. Discover tools from an MCP server
+aifirst pull-tools npx @modelcontextprotocol/server-filesystem /tmp
+
+# 2. Generate C# DTOs
+aifirst gen aifirst.tools.json --namespace MyApp.Tools
+
+# 3. Use typed tools in your code
+```
 
 ```csharp
 await using var transport = new StdioMcpTransport("npx", "@modelcontextprotocol/server-filesystem", "/tmp");
@@ -35,68 +53,34 @@ var tools = await client.ListToolsAsync();
 var result = await client.CallToolAsync("read_file", new { path = "/tmp/test.txt" });
 ```
 
-### JSON Schema Parser & Code Generation
-Parse tool schemas and generate strongly-typed DTOs:
+## Features
 
-```csharp
-// Parse JSON Schema
-var schema = JsonSchemaParser.Parse(toolSchema);
+| Feature | Status | Description |
+|---------|--------|-------------|
+| MCP Client | ✅ | Connect to any MCP server via stdio |
+| Schema Parser | ✅ | Parse JSON Schema from tool definitions |
+| Code Generator | ✅ | Generate C# records from schemas |
+| CLI Tool | ✅ | `pull-tools` and `gen` commands |
+| Source Generator | 🚧 | `[Tool]` attribute with build-time validation |
+| Policy Pipeline | 📋 | Allowlists, redaction, output checks |
+| Tracing | 📋 | Capture and replay tool calls |
 
-// Generate C# records
-var code = DtoGenerator.GenerateRecord(schema, "WeatherRequest", "MyApp.Tools");
-```
+## Testing with MCP Servers
 
-### CLI Tool
+AIFirst.DotNet works with any MCP-compliant server. Try these official ones:
+
 ```bash
-# Discover tools from MCP server and save manifest
+# Filesystem operations
 aifirst pull-tools npx @modelcontextprotocol/server-filesystem /tmp
 
-# Generate C# DTOs from manifest
-aifirst gen aifirst.tools.json --namespace MyApp.Tools --output Tools.cs
+# Memory/knowledge graph
+aifirst pull-tools npx @modelcontextprotocol/server-memory
+
+# Git operations  
+aifirst pull-tools npx @modelcontextprotocol/server-git
 ```
 
-### Attribute DSL (Coming Soon)
-```csharp
-[Tool("weather.getForecast")]
-public static partial Task<Forecast> GetForecastAsync(ForecastRequest request);
-```
-
-The source generator will emit MCP calls for these tool methods.
-
-## Repo Layout
-
-```
-/src
-  /AIFirst.Core          # Core abstractions, schema parser, code generator
-  /AIFirst.Mcp           # MCP client and transports
-  /AIFirst.Roslyn        # Source generator + analyzer
-  /AIFirst.Cli           # CLI tool (aifirst)
-  /AIFirst.DotNet        # Meta package (Core + Mcp + Roslyn)
-/samples
-  /HelloMcp              # Basic MCP connectivity
-  /TypedToolsDemo        # Type-safe tool calls and code generation
-  /PolicyAndTracingDemo  # Governance and observability
-/tests
-  /AIFirst.Core.Tests
-  /AIFirst.Mcp.Tests
-  /AIFirst.Roslyn.Tests
-  /AIFirst.Cli.Tests
-/docs
-  design.md              # Architecture
-  threat-model.md        # Security considerations
-```
-
-## Build
-
-**Requirements:**
-- .NET 8 SDK (CI environment requirement)
-- .NET 6 SDK minimum for local development (with rollForward)
-
-```bash
-dotnet restore
-dotnet build
-dotnet test
-```
+See [MCP Server Directory](https://www.mcplist.ai/) for 775+ community servers.
 
 ## Packages
 
@@ -107,6 +91,16 @@ dotnet test
 | `AIFirst.Mcp` | MCP client and transports |
 | `AIFirst.Roslyn` | Source generator and analyzers |
 | `AIFirst.Cli` | CLI tool (`aifirst`) |
+
+## Build
+
+```bash
+dotnet restore
+dotnet build
+dotnet test
+```
+
+Requires .NET 8 SDK.
 
 ## Roadmap
 
@@ -123,6 +117,12 @@ Track development progress and upcoming features on the [Issues page](https://gi
 **Planned:**
 - M4: Policy pipeline and tracing
 - M5: Documentation and release
+
+## Documentation
+
+- [Use Cases](docs/use-cases.md) - When and why to use AIFirst.DotNet
+- [Design](docs/design.md) - Architecture and components
+- [Threat Model](docs/threat-model.md) - Security considerations
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -22,26 +22,59 @@ AIFirst.DotNet solves these with:
 ✅ **Observability** — trace every prompt and tool call for debugging and compliance  
 ✅ **MCP-native** — leverage the emerging standard for tool interoperability
 
-## Goals
+## Features
 
-- **Typed tools** generated from MCP schemas
-- **Compile-time validation** for tool names and argument shapes
-- **Policy pipeline** for allowlists, redaction, and safety checks
-- **Tracing + replay** for observability and debugging
-- **Broad compatibility** via `netstandard2.0`, `net6.0`, and `net8.0` targets
+### MCP Client
+Connect to any MCP-compliant server and discover tools:
 
-## Repo layout
+```csharp
+await using var transport = new StdioMcpTransport("npx", "@modelcontextprotocol/server-filesystem", "/tmp");
+await using var client = new McpClient(transport);
+
+var tools = await client.ListToolsAsync();
+var result = await client.CallToolAsync("read_file", new { path = "/tmp/test.txt" });
+```
+
+### JSON Schema Parser & Code Generation
+Parse tool schemas and generate strongly-typed DTOs:
+
+```csharp
+// Parse JSON Schema
+var schema = JsonSchemaParser.Parse(toolSchema);
+
+// Generate C# records
+var code = DtoGenerator.GenerateRecord(schema, "WeatherRequest", "MyApp.Tools");
+```
+
+### CLI Tool
+```bash
+# Discover tools from MCP server and save manifest
+aifirst pull-tools npx @modelcontextprotocol/server-filesystem /tmp
+
+# Generate C# DTOs from manifest
+aifirst gen aifirst.tools.json --namespace MyApp.Tools --output Tools.cs
+```
+
+### Attribute DSL (Coming Soon)
+```csharp
+[Tool("weather.getForecast")]
+public static partial Task<Forecast> GetForecastAsync(ForecastRequest request);
+```
+
+The source generator will emit MCP calls for these tool methods.
+
+## Repo Layout
 
 ```
 /src
-  /AIFirst.Core          # Core abstractions
-  /AIFirst.Mcp           # MCP client
+  /AIFirst.Core          # Core abstractions, schema parser, code generator
+  /AIFirst.Mcp           # MCP client and transports
   /AIFirst.Roslyn        # Source generator + analyzer
   /AIFirst.Cli           # CLI tool (aifirst)
   /AIFirst.DotNet        # Meta package (Core + Mcp + Roslyn)
 /samples
   /HelloMcp              # Basic MCP connectivity
-  /TypedToolsDemo        # Type-safe tool calls
+  /TypedToolsDemo        # Type-safe tool calls and code generation
   /PolicyAndTracingDemo  # Governance and observability
 /tests
   /AIFirst.Core.Tests
@@ -52,15 +85,6 @@ AIFirst.DotNet solves these with:
   design.md              # Architecture
   threat-model.md        # Security considerations
 ```
-
-## Attribute DSL
-
-```csharp
-[Tool("weather.getForecast")]
-public static partial Task<Forecast> GetForecastAsync(ForecastRequest request);
-```
-
-The source generator will emit MCP calls for these tool methods.
 
 ## Build
 
@@ -74,34 +98,35 @@ dotnet build
 dotnet test
 ```
 
-**Note:** Tests and samples target net8.0 to match CI. If you have .NET 6 locally, the SDK will roll forward to build net8.0 targets.
+## Packages
 
-## Packages and feeds
+| Package | Description |
+|---------|-------------|
+| `AIFirst.DotNet` | Meta package (includes all below) |
+| `AIFirst.Core` | Core abstractions, schema parser, code generator |
+| `AIFirst.Mcp` | MCP client and transports |
+| `AIFirst.Roslyn` | Source generator and analyzers |
+| `AIFirst.Cli` | CLI tool (`aifirst`) |
 
-**Packages**
-- `AIFirst.DotNet` (meta package)
-- `AIFirst.Core`
-- `AIFirst.Mcp`
-- `AIFirst.Roslyn`
-- `AIFirst.Cli` (tool)
+## Roadmap
 
-**Feeds**
-- NuGet.org for stable releases
-- GitHub Packages for prerelease/nightly builds
-- Azure Artifacts for enterprise/private feeds
-- Cloudsmith for a managed multi-feed option
+Track development progress and upcoming features on the [Issues page](https://github.com/thiagocharao/aifirst-dotnet/issues).
 
-See `docs/nuget.md` for feed setup and release guidance.
+**Completed:**
+- ✅ M0: Build foundation
+- ✅ M1: MCP client with stdio transport
+- ✅ M2: JSON Schema parser and DTO code generator
 
-## Current Status
+**In Progress:**
+- 🚧 M3: Source generator and analyzers
 
-🚧 **MVP in Progress** — Milestone 0 (Build Foundation) complete
-
-See [CHANGELOG.md](CHANGELOG.md) for details and repository issues for implementation progress.
+**Planned:**
+- M4: Policy pipeline and tracing
+- M5: Documentation and release
 
 ## Contributing
 
-This project is in early development. Contributions welcome once Milestone 3 is complete.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -4,8 +4,6 @@
 
 AIFirst.DotNet provides a C#-native DSL for calling MCP tools with compile-time validation and governance. The MVP focuses on an attribute-based DSL that becomes strongly-typed tool calls via a Roslyn source generator and analyzer.
 
-Status note: the CLI workflows and manifest lifecycle below describe the planned MVP flow and are being built across Milestones 1-4.
-
 ## Architecture
 
 ```mermaid
@@ -17,25 +15,50 @@ graph TD
   Cli --> Samples[Samples]
 ```
 
-## Key components
+## Key Components
 
-- **AIFirst.Core**
-  - Tool contracts, policy pipeline, and tracing primitives.
-- **AIFirst.Mcp**
-  - MCP client adapter for tool discovery and invocation.
-- **AIFirst.Roslyn**
-  - `[Tool]` attribute, source generator, and analyzer rules.
-- **AIFirst.Cli**
-  - Planned `pull-tools`, `gen`, and `replay` commands.
+### AIFirst.Core
+- **Tooling**: `ToolContract`, `ToolCall`, `ToolResult` records
+- **Schema**: `JsonSchema`, `JsonSchemaParser`, `CSharpTypeMapper`
+- **CodeGen**: `DtoGenerator` for C# record generation
+- **Policies**: `IPolicy`, `PolicyPipeline` for governance
+- **Tracing**: `TraceEvent`, `ITraceSink` for observability
 
-## Tool manifest lifecycle (planned)
+### AIFirst.Mcp
+- **Client**: `McpClient` with JSON-RPC 2.0 protocol
+- **Transport**: `IMcpTransport`, `StdioMcpTransport`
+- Tool discovery via `tools/list`
+- Tool invocation via `tools/call`
 
-1. `aifirst pull-tools` connects to an MCP server.
-2. Tool schemas are captured in `aifirst.tools.json`.
-3. `aifirst gen` generates C# DTOs for tool parameters and results.
-4. The Roslyn generator/analyzer uses the manifest for build-time validation.
+### AIFirst.Roslyn
+- `[Tool]` attribute for marking tool methods
+- Source generator (in progress)
+- Analyzer rules (in progress)
 
-## Policy pipeline ordering
+### AIFirst.Cli
+- `aifirst pull-tools` - Connect to MCP server and save manifest
+- `aifirst gen` - Generate C# DTOs from tool manifest
+- `aifirst replay` - Replay traces (planned)
+
+## Tool Manifest Lifecycle
+
+1. `aifirst pull-tools` connects to an MCP server
+2. Tool schemas are captured in `aifirst.tools.json`
+3. `aifirst gen` generates C# DTOs for tool parameters
+4. The Roslyn generator/analyzer uses the manifest for build-time validation
+
+## JSON Schema Support
+
+The schema parser handles:
+- Primitive types: string, integer, number, boolean
+- Complex types: object, array
+- Format hints: date-time, uri, uuid, guid
+- Nullability via `nullable` property
+- Required vs optional properties
+- Nested objects and arrays
+- `$ref` references
+
+## Policy Pipeline Ordering
 
 Policies execute in the following order:
 
@@ -43,7 +66,7 @@ Policies execute in the following order:
 2. MCP tool invocation
 3. `OnAfterToolCall` (output safety checks, audit logging)
 
-## Trace format (MVP)
+## Trace Format (MVP)
 
 Each trace event includes:
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,137 @@
+# Use Cases
+
+## When to Use AIFirst.DotNet
+
+AIFirst.DotNet is designed for .NET developers building AI-powered applications that call external tools via MCP (Model Context Protocol). It's especially valuable when you need:
+
+- **Compile-time safety** for tool calls
+- **Governance and compliance** (audit trails, PII redaction)
+- **Multi-tool orchestration** across MCP servers
+- **Debugging capabilities** for AI agent behavior
+
+## Real-World Scenarios
+
+### 1. Enterprise AI Assistants
+
+Building an internal AI assistant that queries databases, sends emails, and accesses internal APIs:
+
+```csharp
+// Without AIFirst: Runtime errors, no audit trail, potential PII leaks
+var result = await llm.CallTool("send_emal", jsonArgs); // typo? schema wrong?
+
+// With AIFirst: Compile-time safety, redaction, tracing
+[Tool("email.send")]
+public partial Task<EmailResult> SendEmailAsync(SendEmailRequest request);
+// ^ Analyzer catches typos and schema mismatches at build time
+// ^ Policy pipeline redacts PII before logging
+// ^ Traces capture everything for compliance audits
+```
+
+### 2. Multi-Tool AI Agents
+
+Orchestrating multiple MCP servers (filesystem, database, APIs) in a single agent:
+
+```bash
+# Pull tools from multiple servers
+aifirst pull-tools npx @modelcontextprotocol/server-filesystem /data
+aifirst pull-tools npx @modelcontextprotocol/server-postgres "postgres://..."
+aifirst gen --namespace MyAgent.Tools
+```
+
+```csharp
+// Generated typed tools - no JSON wrangling
+[Tool("read_file")] 
+public partial Task<FileContent> ReadFileAsync(ReadFileRequest request);
+
+[Tool("query")]
+public partial Task<QueryResult> QueryDatabaseAsync(QueryRequest request);
+```
+
+### 3. Regulated Industries
+
+Healthcare, finance, and legal applications where compliance is critical:
+
+| Requirement | AIFirst Solution |
+|-------------|------------------|
+| Only approved tools | Allowlist policy |
+| No PII in logs | Redaction policy |
+| Audit trail | Trace sink with replay |
+| Security review | Build-time validation |
+
+### 4. AI Coding Tools Development
+
+Testing and developing MCP tools that IDEs like VS Code, Cursor, or Windsurf will consume:
+
+```bash
+# Test your MCP server with AIFirst CLI
+aifirst pull-tools node ./my-server.js
+aifirst gen --namespace MyServer.Tools
+
+# Validate tool schemas compile correctly
+dotnet build
+```
+
+## Comparison
+
+| Scenario | Without AIFirst | With AIFirst |
+|----------|-----------------|--------------|
+| Typo in tool name | Runtime error after deployment | Build error ❌ |
+| Schema mismatch | Silent failures, weird behavior | Build error ❌ |
+| PII in logs | Compliance nightmare | Auto-redacted ✅ |
+| "Why did AI do that?" | No visibility | Full trace replay ✅ |
+| Tool sprawl | Any tool can be called | Allowlist enforced ✅ |
+| Multi-server orchestration | Manual JSON wrangling | Typed methods ✅ |
+
+## When NOT to Use AIFirst.DotNet
+
+- **Simple scripts**: If you're just testing an MCP server once, use the raw SDK
+- **Non-.NET projects**: AIFirst.DotNet is C#-specific
+- **No governance needs**: If you don't need policies, tracing, or compile-time checks
+
+## Testing with MCP Servers
+
+### Official Reference Servers
+
+These npm packages are great for testing:
+
+| Server | Command | Description |
+|--------|---------|-------------|
+| Filesystem | `npx @modelcontextprotocol/server-filesystem /tmp` | File operations |
+| Memory | `npx @modelcontextprotocol/server-memory` | Knowledge graph |
+| Git | `npx @modelcontextprotocol/server-git` | Git operations |
+| Fetch | `npx @modelcontextprotocol/server-fetch` | Web fetching |
+| Time | `npx @modelcontextprotocol/server-time` | Time utilities |
+| Everything | `npx @modelcontextprotocol/server-everything` | Demo server |
+
+### Quick Start
+
+```bash
+# 1. Discover tools
+aifirst pull-tools npx @modelcontextprotocol/server-filesystem /tmp
+
+# 2. Generate DTOs
+aifirst gen aifirst.tools.json --namespace MyApp.Tools --output Tools.cs
+
+# 3. Use in code
+await using var transport = new StdioMcpTransport("npx", "@modelcontextprotocol/server-filesystem", "/tmp");
+await using var client = new McpClient(transport);
+
+var tools = await client.ListToolsAsync();
+var result = await client.CallToolAsync("read_file", new { path = "/tmp/test.txt" });
+```
+
+### MCP Inspector
+
+For interactive debugging:
+
+```bash
+npx @modelcontextprotocol/inspector npx @modelcontextprotocol/server-filesystem /tmp
+```
+
+Opens a web UI to explore tools, test calls, and inspect responses.
+
+## Resources
+
+- [MCP Specification](https://modelcontextprotocol.io/)
+- [Official MCP Servers](https://github.com/modelcontextprotocol/servers)
+- [MCP Server Directory](https://www.mcplist.ai/) - 775+ community servers


### PR DESCRIPTION
## Summary

Updates all markdown documentation to reflect the current state after M1 and M2 completion.

## Changes

### README.md
- Added feature examples with code snippets (MCP Client, Schema Parser, CLI)
- Added packages table with descriptions
- Replaced 'Current Status' with 'Roadmap' section
- **Added link to [Issues page](https://github.com/thiagocharao/aifirst-dotnet/issues) for tracking progress**
- Updated repo layout description

### CHANGELOG.md
- Organized by milestones (M0, M1, M2)
- Documented all features added:
  - M2: JSON Schema parser, type mapper, DTO generator, CLI commands
  - M1: MCP client, stdio transport, JSON-RPC protocol
  - M0: Core abstractions, policy pipeline, tracing

### CONTRIBUTING.md
- Updated development status with Issues link
- Fixed repo URL (was ai-first, now aifirst-dotnet)
- Simplified status section

### docs/design.md
- Documented all current components in detail
- Added JSON Schema support section
- Updated component descriptions to reflect implementation

## Key Point

The README now links directly to the Issues page for roadmap tracking:

```markdown
## Roadmap

Track development progress and upcoming features on the [Issues page](https://github.com/thiagocharao/aifirst-dotnet/issues).
```

This keeps documentation simple and avoids duplication with the issue tracker.